### PR TITLE
Implemented automatic documentation generation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,3 @@
-# ATTENTION: no deployment should be done until serverless.yml is properly setup
 name: deploy
 on:
   push:
@@ -10,11 +9,44 @@ on:
       - 'layer/**'
       - 'lambdas/**'
       - 'resources/**'
+      - 'docs/**'
 jobs:
-  deploy:
+  generate-docs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Import GPG key
+      uses: crazy-max/ghaction-import-gpg@v2
+      with:
+        git_user_signingkey: true
+        git_commit_gpgsign: true
+      env:
+        GPG_PRIVATE_KEY: ${{ secrets.KASKADI_BOT_GPG_PRIVATE_KEY }}
+        PASSPHRASE: ${{ secrets.KASKADI_BOT_GPG_PRIVATE_PASSPHRASE }}
+    - name: Generate documentation
+      uses: kaskadi/action-generate-docs@master
+      with:
+        type: api
+        template: docs/template.md
+      env:
+        COGNITO_USER_POOL_ARN: ${{ secrets.COGNITO_USER_POOL_ARN }}
+        COGNITO_CLIENT_ID: ${{ secrets.COGNITO_CLIENT_ID }}
+        COGNITO_IDENTITY_POOL_ID: ${{ secrets.COGNITO_IDENTITY_POOL_ID }}
+        CFD_KEY_PAIR_ID: ${{ secrets.CFD_KEY_PAIR_ID }}
+        CFD_PRIVATE_KEY: ${{ secrets.CFD_PRIVATE_KEY }}
+  deploy:
+    runs-on: ubuntu-latest
+    needs: generate-docs
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 12
+        registry-url: https://registry.npmjs.org/
+    - name: Pull latest commit
+      run: |
+        git config pull.rebase false
+        git pull
     - name: Install dependencies
       run: npm i
     - name: serverless check

--- a/docs/template.md
+++ b/docs/template.md
@@ -1,0 +1,29 @@
+![](https://img.shields.io/github/package-json/v/kaskadi/auth-api)
+![](https://img.shields.io/badge/code--style-standard-blue)
+![](https://img.shields.io/github/license/kaskadi/auth-api?color=blue)
+
+**GitHub Actions workflows status**
+
+[![](https://img.shields.io/github/workflow/status/kaskadi/auth-api/deploy?label=deployed&logo=Amazon%20AWS)](https://github.com/kaskadi/auth-api/actions?query=workflow%3Adeploy)
+[![](https://img.shields.io/github/workflow/status/kaskadi/auth-api/build?label=build&logo=mocha)](https://github.com/kaskadi/auth-api/actions?query=workflow%3Abuild)
+[![](https://img.shields.io/github/workflow/status/kaskadi/auth-api/syntax-check?label=syntax-check&logo=serverless)](https://github.com/kaskadi/auth-api/actions?query=workflow%3Asyntax-check)
+
+**CodeClimate**
+
+[![](https://img.shields.io/codeclimate/maintainability/kaskadi/auth-api?label=maintainability&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/auth-api)
+[![](https://img.shields.io/codeclimate/tech-debt/kaskadi/auth-api?label=technical%20debt&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/auth-api)
+[![](https://img.shields.io/codeclimate/coverage/kaskadi/auth-api?label=test%20coverage&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/auth-api)
+
+**LGTM**
+
+[![](https://img.shields.io/lgtm/grade/javascript/github/kaskadi/auth-api?label=code%20quality&logo=LGTM)](https://lgtm.com/projects/g/kaskadi/auth-api/?mode=list&logo=LGTM)
+
+<!-- You can add badges inside of this section if you'd like -->
+
+****
+
+<!-- automatically generated documentation will be placed in here -->
+{{>main}}
+<!-- automatically generated documentation will be placed in here -->
+
+<!-- You can customize this template as you'd like! -->

--- a/lambdas/create-cfd-signed-url/serverless.yml
+++ b/lambdas/create-cfd-signed-url/serverless.yml
@@ -17,3 +17,5 @@ events:
       authorizer:
         type: COGNITO_USER_POOLS
         authorizerId: !Ref CognitoAuthorizer
+      kaskadi-docs:
+        description: This endpoint returns a CloudFront signed URL that can be used for uploading content into a private CDN. 

--- a/lambdas/login/serverless.yml
+++ b/lambdas/login/serverless.yml
@@ -19,7 +19,7 @@ events:
         description: This endpoint allows user to retrieve their authentication data given they provided a proper username and password.
         body:
           - key: method
-            description: 'Defines the login method used. Valid values: `'Cognito'`, `'Google'`'
+            description: 'Defines the authentication provider. Valid values: `'Cognito'`, `'Google'`'
             default: 'Cognito'
           - key: token
             description: Access token to login. This is used only when logging in via Google.

--- a/lambdas/login/serverless.yml
+++ b/lambdas/login/serverless.yml
@@ -15,3 +15,15 @@ events:
       method: post
       path: login
       cors: true
+      kaskadi-docs:
+        description: This endpoint allows user to retrieve their authentication data given they provided a proper username and password.
+        body:
+          - key: method
+            description: 'Defines the login method used. Valid values: `'Cognito'`, `'Google'`'
+            default: 'Cognito'
+          - key: token
+            description: Access token to login. This is used only when logging in via Google.
+          - key: Username
+            description: Username used for logging in via AWS Cognito
+          - key: Password
+            description: Password associated with the given username for logging in via AWS Cognito

--- a/lambdas/login/serverless.yml
+++ b/lambdas/login/serverless.yml
@@ -22,8 +22,8 @@ events:
             description: 'Defines the authentication provider. Valid values: `'Cognito'`, `'Google'`'
             default: 'Cognito'
           - key: token
-            description: Access token to login. This is used only when logging in via Google.
+            description: Access token to login. This is used only when logging in via **Google**.
           - key: Username
-            description: Username used for logging in via AWS Cognito
+            description: Username used for logging in via **AWS Cognito**.
           - key: Password
-            description: Password associated with the given username for logging in via AWS Cognito
+            description: Password associated with the given username for logging in via **AWS Cognito**.

--- a/lambdas/logout/serverless.yml
+++ b/lambdas/logout/serverless.yml
@@ -12,3 +12,11 @@ events:
       method: post
       path: logout
       cors: true
+      kaskadi-docs:
+        description: This endpoint allows user to invalidate any authentication tokens generated with their credentials. **This currently does not support Google as an authentication provider.**
+        body:
+          - key: method
+            description: 'Defines the authentication provider. Valid values: `'Cognito'`, `'Google'`'
+            default: 'Cognito'
+          - key: accessToken
+            description: Access token provided when logging in. This applies only to session created via **Cognito**.

--- a/lambdas/refresh-session/serverless.yml
+++ b/lambdas/refresh-session/serverless.yml
@@ -14,3 +14,11 @@ events:
       method: post
       path: refresh
       cors: true
+      kaskadi-docs:
+        description: This endpoint allows user to refresh their access token in order to avoid having to log in again. This will work until their refresh token expires. **This currently does not support Google as an authentication provider.**
+        body:
+          - key: method
+            description: 'Defines the authentication provider. Valid values: `'Cognito'`, `'Google'`'
+            default: 'Cognito'
+          - key: refreshToken
+            description: Refresh token provided when logging in. This applies only to session created via **Cognito**.

--- a/layer/serverless.yml
+++ b/layer/serverless.yml
@@ -1,6 +1,6 @@
 path: layer
 name: ${self:service.name}-layer
-description": Layer for ${self:service.name}
+description: Layer for ${self:service.name}
 compatibleRuntimes:
   - nodejs10.x
   - nodejs12.x

--- a/tools/add-lambda/data/serverless.yml
+++ b/tools/add-lambda/data/serverless.yml
@@ -1,5 +1,6 @@
 handler: lambdas/{{name}}/{{name}}.handler
 name: {{name}}
+# customize as needed to connect your lambda function to layers
 layers:
   - { Ref: ApiLayerLambdaLayer }
 package:
@@ -11,3 +12,22 @@ events:
       method: {{method}}
       path: {{path}}
       cors: true
+      # custom fields allowing you to describe your endpoint in order to automatically document it
+      kaskadi-docs:
+        description: placeholder endpoint # describe what this endpoint is used for
+        # this field helps you describe any query string parameter accepted by this endpoint
+        queryStringParameters:
+          - key: key1
+            description: first key
+          - key: key2
+            description: second key
+            default: 35 # you can give a default value
+        # this field helps you describe the body expected by your endpoint
+        body:
+          - key: param1
+            description: first body param
+            default: 'hello'
+          - key: param2
+            description: second body param
+            default: true
+            

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -1,11 +1,8 @@
-# Layer
-echo "installing layer"
-echo "changing directory"
-cd layer/nodejs
-echo $(pwd)
-echo "installing dependencies"
-npm i
-echo "done"
-echo "cleaning up"
-cd ../..
-echo $(pwd)
+#!/bin/bash
+
+if [ -d "layer" ] && [ -f "layer/nodejs/package.json" ]
+  then
+    cd layer/nodejs || exit
+    npm i
+    cd ../../
+fi


### PR DESCRIPTION
**Changes description**
Implemented automatic documentation generation using `action-generate-docs` GitHub action.

**New features**
- _docs template:_ template for documentation generation located under `docs/template.md`

**Updated features**
- _`deploy` workflow:_ now includes a `generate-docs` step which automatically generate documentation using `action-generate-docs` and a template located under `docs/template.md`
- _endpoints config file:_ now includes custom `kaskadi-docs` field for documentation generation
- _install script:_ updated install script to handle cases where no layer exists
- _`add-lambda` tool:_ added placeholder `kaskadi-docs` field in base config file
- _layer config file:_ fixed `description` field key