### PR TITLE
Split deployment workflow

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -1,4 +1,4 @@
-name: deploy
+name: generate-docs
 on:
   push:
     branches:
@@ -9,7 +9,7 @@ on:
       - 'package.json'
       - 'layer/**'
       - 'resources/**'
-      - 'lambdas/**'
+      - 'docs/**'
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_KEY_SECRET }}
@@ -19,9 +19,8 @@ env:
   CFD_KEY_PAIR_ID: ${{ secrets.CFD_KEY_PAIR_ID }}
   CFD_PRIVATE_KEY: ${{ secrets.CFD_PRIVATE_KEY }}
 jobs:
-  deploy:
+  generate-docs:
     runs-on: ubuntu-latest
-    if: github.repository != 'kaskadi/template-kaskadi-api' # this is done to skip deploy workflow to avoid the common Serverless API Gateway error when the stack hasn't been deployed yet (template won't be deployed)
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
@@ -31,10 +30,20 @@ jobs:
     - name: Install dependencies
       run: npm i
     - name: serverless check
+      if: github.repository != 'kaskadi/template-kaskadi-api' # this is done to skip this step to avoid the common Serverless API Gateway error when the stack hasn't been deployed yet (template won't be deployed)
       uses: serverless/github-action@master
       with:
         args: deploy --noDeploy
-    - name: serverless deploy
-      uses: serverless/github-action@master
+    - name: Import GPG key
+      uses: crazy-max/ghaction-import-gpg@v2
       with:
-        args: deploy -v
+        git_user_signingkey: true
+        git_commit_gpgsign: true
+      env:
+        GPG_PRIVATE_KEY: ${{ secrets.KASKADI_BOT_GPG_PRIVATE_KEY }}
+        PASSPHRASE: ${{ secrets.KASKADI_BOT_GPG_PRIVATE_PASSPHRASE }}
+    - name: Generate documentation
+      uses: kaskadi/action-generate-docs@master
+      with:
+        type: api
+        template: docs/template.md

--- a/.github/workflows/syntax-check.yml
+++ b/.github/workflows/syntax-check.yml
@@ -18,6 +18,7 @@ env:
 jobs:
   syntax-check:
     runs-on: ubuntu-latest
+    if: github.repository != 'kaskadi/template-kaskadi-api' # this is done to skip deploy workflow to avoid the common Serverless API Gateway error when the stack hasn't been deployed yet (template won't be deployed)
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies

--- a/docs/template.md
+++ b/docs/template.md
@@ -4,9 +4,10 @@
 
 **GitHub Actions workflows status**
 
-[![](https://img.shields.io/github/workflow/status/kaskadi/auth-api/deploy?label=deployed&logo=Amazon%20AWS)](https://github.com/kaskadi/auth-api/actions?query=workflow%3Adeploy)
-[![](https://img.shields.io/github/workflow/status/kaskadi/auth-api/build?label=build&logo=mocha)](https://github.com/kaskadi/auth-api/actions?query=workflow%3Abuild)
-[![](https://img.shields.io/github/workflow/status/kaskadi/auth-api/syntax-check?label=syntax-check&logo=serverless)](https://github.com/kaskadi/auth-api/actions?query=workflow%3Asyntax-check)
+[![Deploy status](https://img.shields.io/github/workflow/status/kaskadi/auth-api/deploy?label=deployed&logo=Amazon%20AWS)](https://github.com/kaskadi/auth-api/actions?query=workflow%3Adeploy)
+[![Build status](https://img.shields.io/github/workflow/status/kaskadi/auth-api/build?label=build&logo=mocha)](https://github.com/kaskadi/auth-api/actions?query=workflow%3Abuild)
+[![Syntax check status](https://img.shields.io/github/workflow/status/kaskadi/auth-api/syntax-check?label=syntax-check&logo=serverless)](https://github.com/kaskadi/auth-api/actions?query=workflow%3Asyntax-check)
+[![Docs generation status](https://img.shields.io/github/workflow/status/kaskadi/auth-api/generate-docs?label=docs&logo=read-the-docs)](https://github.com/kaskadi/auth-api/actions?query=workflow%3Agenerate-docs)
 
 **CodeClimate**
 


### PR DESCRIPTION
**Changes description**
Extracted `generate-docs` step from `deploy` workflow into a separate workflow. Both workflows check for syntax error in `serverless.yml`. This was done to prevent deployment for failing in case the workflow couldn't generate the documentation automatically (we don't need an up to date documentation to deploy resources).

**New features**
- _`generate-docs` workflow:_ former `generate-docs` step of `deploy` workflow. Now also checks for syntax error in config file.

**Updated features**
- _`deploy` workflow:_ removed `generate-docs` step and fixed triggers.
- _conditional step/job run:_ `deploy`, `generate-docs` and `syntax-check` all checks (either at job or at step level) if the calling repository is the template. If yes they would skip the associated job/step (Serverless task). This is done to avoid running a Serverless related task that will fail because of the common Serverless API Gateway error (`stack id does not exist`) because the template hasn't actually been deployed.